### PR TITLE
Modify functions to PS parameter conventions

### DIFF
--- a/OctopusEnergy-Helpers/Private/Get-OctopusEnergyHelperAPIParameter.ps1
+++ b/OctopusEnergy-Helpers/Private/Get-OctopusEnergyHelperAPIParameter.ps1
@@ -1,0 +1,92 @@
+<#
+.SYNOPSIS
+    Retrieves the Octopus Energy API parameters
+.DESCRIPTION
+    Retrieves the Octopus Energy API parameter names from the parameter aliases defined in the function
+.PARAMETER InvocationInfo
+    InvocationInfo object from the calling function
+.PARAMETER HashTable
+    Hashtable containing the values to pass to the Octopus Energy API
+.PARAMETER Clear
+    Array of values which should be sent empty to Octopus Energy API
+.PARAMETER Join
+    Hashtable containing values which need to be joined by specific separator
+.PARAMETER Exclude
+    Array of parameter names which should be excluded from the output hashtable
+.EXAMPLE
+    C:\PS>$MyInvocation | Get-OctopusEnergyHelperAPIParameter -HashTable $hashTable
+    Retrieve the Octopus Energy API parameter names from the supplied invocation object
+#>
+Function Get-OctopusEnergyHelperAPIParameter
+{
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    Param(
+        [Parameter(Mandatory=$True,ValueFromPipeline=$True)]
+        [System.Management.Automation.InvocationInfo]$InvocationInfo,
+
+        [hashtable] $HashTable,
+
+        [string[]] $Clear=@(),
+
+        [hashtable] $Join=@{},
+
+        [string[]] $Exclude=@()
+    )
+
+    $parameterAction = $Hashtable
+    $parameterAction.Remove("InputHashTable")
+    $parameterAction.Remove("InvocationInfo")
+
+    $outputHashtable = @{}
+
+    # Avoiding sending any common parameters
+    $Exclude += [System.Management.Automation.PSCmdlet]::CommonParameters
+    $Exclude += [System.Management.Automation.PSCmdlet]::OptionalCommonParameters
+    # AKey is sent as part of the request header
+    $Exclude += "APIKey"
+
+    #Remove excluded variables
+    $workingHash = $Hashtable.GetEnumerator() | Where-Object {$_.Key -notin $Exclude}
+
+    #Ignore common parameters and find aliases of parameters which need to be renamed
+    $FunctionInfo = (Get-Command -Name $InvocationInfo.InvocationName)
+    $parameterMetadata = $FunctionInfo.Parameters.Values
+    $aliases = $parameterMetadata | Select-Object -Property Name, Aliases | Where-Object {$_.Name -in $workingHash.Key -and $_.Aliases}
+    $rename = @{}
+    foreach($item in $aliases)
+    {   # Rename parameter using first alias
+        $rename[$item.name] = $item.aliases[0]
+    }
+
+    foreach($cItem in $Clear)
+    {
+        If($Hashtable.ContainsKey($cItem))
+        {
+            $Hashtable[$_] = ""
+        }
+        else
+        {
+            $outputHashtable[$cItem] = ""
+        }
+    }
+
+    foreach($item in $workingHash)
+    {
+        $itemName = $item.Name
+
+        Switch($itemName)
+        {
+            {$rename.ContainsKey($_)}{
+                $outputHashtable[$rename[$_]] = $Hashtable[$_]
+            }
+            {$Join.ContainsKey($_)}{
+                $outputHashtable[$_] = $Hashtable[$_] -join $Join[$_]
+            }
+            Default {
+                $outputHashtable[$_] = $Hashtable[$_]
+            }
+        }
+    }
+    Return $outputHashtable
+}

--- a/OctopusEnergy-Helpers/Private/Get-OctopusEnergyHelperParameterValue.ps1
+++ b/OctopusEnergy-Helpers/Private/Get-OctopusEnergyHelperParameterValue.ps1
@@ -1,0 +1,47 @@
+<#
+.SYNOPSIS
+    Get the all the parameter which have values
+.DESCRIPTION
+    Combines the default parameter values with the parameters from bound parameters excluding any null parameters
+.PARAMETER InvocationInfo
+    InvocationInfo object supplied by the calling function
+.PARAMETER BoundParameters
+    The $PSBoundParameters hashtable supplied by the calling function
+.EXAMPLE
+    C:\PS>$MyInvocation | Get-OctopusEnergyHelperParameterValue -BoundParameters $PSBoundParameters
+    Get all the parameters which values from $MyInvocation and $PSBoundParameter objects
+.OUTPUTS
+    Returns a hashtable with all parameters which are bound or have non-null defaults
+#>
+Function Get-OctopusEnergyHelperParameterValue
+{
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory=$True,ValueFromPipeline=$True)]
+        [System.Management.Automation.InvocationInfo]$InvocationInfo,
+
+        [Parameter(Mandatory=$True)]
+        [hashtable]$BoundParameters
+    )
+
+    $allParameterValues = @{}
+    foreach($parameter in $InvocationInfo.MyCommand.Parameters.GetEnumerator())
+    {
+        $value = Get-Variable -Name $parameter.Key -ValueOnly -ErrorAction Ignore
+        # Check if variable value is not null
+        if($null -ne $value)
+        {
+            # Check if variable is not a null type
+            if($value -ne ($null -as $parameter.Value.ParameterType))
+            {
+                $allParameterValues[$parameter.Key] = $value
+            }
+        }
+        if($BoundParameters.ContainsKey($parameter.Key))
+        {
+            $allParameterValues[$parameter.Key] = $BoundParameters[$parameter.Key]
+        }
+    }
+    return $allParameterValues
+}

--- a/OctopusEnergy-Helpers/Public/Consumption/Get-OctopusEnergyHelperElectricityUsed.ps1
+++ b/OctopusEnergy-Helpers/Public/Consumption/Get-OctopusEnergyHelperElectricityUsed.ps1
@@ -3,22 +3,22 @@
    Retrieves the consumption for a smart electricity meter.
 .DESCRIPTION
    Returns the consumption for a smart electricity meter. No parameters required if configuration has been set.
-.PARAMETER apikey
+.PARAMETER APIKey
    The Octopus Energy API Key
-.PARAMETER mpan
+.PARAMETER MPAN
    The mpan of the electricity meter
-.PARAMETER serial_number
+.PARAMETER SerialNumber
    The electricity meter's serial number
-.PARAMETER period_from
+.PARAMETER PeriodFrom
    Show consumption from the given datetime (inclusive). This parameter can be provided on its own.
-.PARAMETER period_to
+.PARAMETER PeriodTo
    Show consumption to the given datetime (exclusive). This parameter also requires providing the period_from parameter to create a range.
-.PARAMETER page_size
+.PARAMETER PageSize
    Page size of returned results. Default is 100, maximum is 25,000 to give a full year of half-hourly consumption details.
-.PARAMETER order_by
+.PARAMETER OrderBy
    Ordering of results returned. Default is that results are returned in reverse order from latest available figure.
    Valid values: * ‘period’, to give results ordered forward. * ‘-period’, (default), to give results ordered from most recent backwards.
-.PARAMETER group_by
+.PARAMETER GroupBy
    Grouping of consumption. Default is that consumption is returned in half-hour periods. Possible alternatives are: * ‘hour’ * ‘day’ * ‘week’ * ‘month’ * ‘quarter’
 .INPUTS
    None
@@ -30,49 +30,50 @@
 .EXAMPLE
    C:\PS>Get-OctopusEnergyHelperElectricityUsed
    Retrieve the electricity consumption details using details configured with Set-OctopusEnergyHelperConfig
+.LINK
+   https://developer.octopus.energy/docs/api/#consumption
 #>
 function Get-OctopusEnergyHelperElectricityUsed
 {
    [CmdletBinding(SupportsShouldProcess=$true)]
    Param(
       [ValidateNotNullOrEmpty()]
-      [securestring]$ApiKey=(Get-OctopusEnergyHelperAPIAuth),
+      [securestring]$APIKey=(Get-OctopusEnergyHelperAPIAuth),
 
       [ValidateNotNullOrEmpty()]
-      [string]$mpan=(Get-OctopusEnergyHelperConfig -property mpan),
+      [string]$MPAN=(Get-OctopusEnergyHelperConfig -property mpan),
 
       [ValidateNotNullOrEmpty()]
-      [string]$serial_number=(Get-OctopusEnergyHelperConfig -property elec_serial_number),
+      [Alias("serial_number")]
+      [string]$SerialNumber=(Get-OctopusEnergyHelperConfig -property elec_serial_number),
 
       [Parameter(ParameterSetName='InclusiveDateRange')]
       [Parameter(Mandatory=$true,ParameterSetName='ExclusiveDateRange')]
-      [datetime]$period_from,
+      [Alias("period_from")]
+      [datetime]$PeriodFrom,
 
       [Parameter(Mandatory=$true,ParameterSetName='ExclusiveDateRange')]
-      [datetime]$period_to,
+      [Alias("period_to")]
+      [datetime]$PeriodTo,
 
       [ValidateRange(1,25000)]
-      [int]$page_size,
+      [Alias("page_size")]
+      [int]$PageSize=1500,
 
       [ValidateSet("period","-period")]
-      [string]$order_by,
+      [Alias("order_by")]
+      [string]$OrderBy,
 
       [ValidateSet("hour","day","week","month","quarter")]
-      [string]$group_by
+      [Alias("group_by")]
+      [string]$GroupBy
    )
 
-   foreach($param in $MyInvocation.MyCommand.Parameters.GetEnumerator())
-   {
-      $var = Get-Variable -Name $param.Key -ErrorAction SilentlyContinue
-      if ( $var.value -and (! $PSBoundParameters.ContainsKey($var.Name)))
-      {
-         $PSBoundParameters.Add($param.Key,$var.value)
-      }
-   }
+   $allParameterValues = $MyInvocation | Get-OctopusEnergyHelperParameterValue -BoundParameters $PSBoundParameters
 
    if( $pscmdlet.ShouldProcess("Octopus Energy API", "Retrieve Electricity Consumption") )
    {
-      $response = Get-OctopusEnergyHelperConsumption @PSBoundParameters
+      $response = Get-OctopusEnergyHelperConsumption @allParameterValues
       Return $response
    }
 }

--- a/OctopusEnergy-Helpers/Public/Consumption/Get-OctopusEnergyHelperGasUsed.ps1
+++ b/OctopusEnergy-Helpers/Public/Consumption/Get-OctopusEnergyHelperGasUsed.ps1
@@ -3,33 +3,35 @@
    Retrieves the consumption for a smart gas meter
 .DESCRIPTION
    Returns the consumption for a smart gas meter. No parameters required if configuration has been set via the Set-OctopusEnergyHelperConfig command
-.PARAMETER apikey
+.PARAMETER APIKey
    The Octopus Energy API Key
-.PARAMETER mprn
-   The mprn of the gas meter
-.PARAMETER serial_number
+.PARAMETER MPRN
+   The MPRN of the gas meter
+.PARAMETER SerialNumber
    The gas meter's serial number
-.PARAMETER period_from
+.PARAMETER PeriodFrom
    Show consumption from the given datetime (inclusive). This parameter can be provided on its own.
-.PARAMETER period_to
+.PARAMETER PeriodTo
    Show consumption to the given datetime (exclusive). This parameter also requires providing the period_from parameter to create a range.
-.PARAMETER page_size
+.PARAMETER PageSize
    Page size of returned results. Default is 100, maximum is 25,000 to give a full year of half-hourly consumption details.
-.PARAMETER order_by
+.PARAMETER OrderBy
    Ordering of results returned. Default is that results are returned in reverse order from latest available figure.
    Valid values: * ‘period’, to give results ordered forward. * ‘-period’, (default), to give results ordered from most recent backwards.
-.PARAMETER group_by
+.PARAMETER GroupBy
    Grouping of consumption. Default is that consumption is returned in half-hour periods. Possible alternatives are: * ‘hour’ * ‘day’ * ‘week’ * ‘month’ * ‘quarter’
 .INPUTS
    None
 .OUTPUTS
    Returns a PSCustomObject with details of the consumption
 .EXAMPLE
-   C:\PS>Get-OctopusEnergyHelperConsumption -mprn 1234567890 -serial_number A1B2C3D4
+   C:\PS>Get-OctopusEnergyHelperGasUsed -MPRN 1234567890 -SerialNumber A1B2C3D4
    Retrieve the consumption details for MPRN 1234567890 with serial number A1B2C3D4
 .EXAMPLE
    C:\PS>Get-OctopusEnergyHelperGasUsed
    Retrieve the electricity consumption details using details configured with Set-OctopusEnergyHelperConfig
+.LINK
+   https://developer.octopus.energy/docs/api/#consumption
 #>
 function Get-OctopusEnergyHelperGasUsed
 {
@@ -42,37 +44,36 @@ function Get-OctopusEnergyHelperGasUsed
       [string]$mprn=(Get-OctopusEnergyHelperConfig -property mprn),
 
       [ValidateNotNullOrEmpty()]
-      [string]$serial_number=(Get-OctopusEnergyHelperConfig -property gas_serial_number),
+      [Alias("serial_number")]
+      [string]$SerialNumber=(Get-OctopusEnergyHelperConfig -property gas_serial_number),
 
       [Parameter(ParameterSetName='InclusiveDateRange')]
       [Parameter(Mandatory=$true,ParameterSetName='ExclusiveDateRange')]
-      [datetime]$period_from,
+      [Alias("period_from")]
+      [datetime]$PeriodFrom,
 
       [Parameter(Mandatory=$true,ParameterSetName='ExclusiveDateRange')]
-      [datetime]$period_to,
+      [Alias("period_to")]
+      [datetime]$PeriodTo,
 
       [ValidateRange(1,25000)]
-      [int]$page_size,
+      [Alias("page_size")]
+      [int]$PageSize=1500,
 
       [ValidateSet("period","-period")]
-      [string]$order_by,
+      [Alias("order_by")]
+      [string]$OrderBy,
 
       [ValidateSet("hour","day","week","month","quarter")]
-      [string]$group_by
+      [Alias("group_by")]
+      [string]$GroupBy
    )
 
-   foreach($param in $MyInvocation.MyCommand.Parameters.GetEnumerator())
-   {
-      $var = Get-Variable -Name $param.Key -ErrorAction SilentlyContinue
-      if ( $var.value -and (! $PSBoundParameters.ContainsKey($var.Name)))
-      {
-         $PSBoundParameters.Add($param.Key,$var.value)
-      }
-   }
+   $allParameterValues = $MyInvocation | Get-OctopusEnergyHelperParameterValue -BoundParameters $PSBoundParameters
 
    if( $pscmdlet.ShouldProcess("Octopus Energy API", "Retrieve Gas Consumption") )
    {
-      $response = Get-OctopusEnergyHelperConsumption @PSBoundParameters
+      $response = Get-OctopusEnergyHelperConsumption @allParameterValues
       Return $response
    }
 }

--- a/OctopusEnergy-Helpers/Public/Consumption/README.md
+++ b/OctopusEnergy-Helpers/Public/Consumption/README.md
@@ -7,13 +7,39 @@ This cmdlet retrieves the consumption for the specified smart gas or electricity
 
 ```powershell
 # Electricity meter
-Get-OctopusEnergyHelperConsumption -mpan 1234567890123 -serial_number EM123456789
+Get-OctopusEnergyHelperConsumption -MPAN 1234567890123 -SerialNumber EM123456789
+consumption interval_start            interval_end
+----------- --------------            ------------
+      0.000 2020-01-01T00:00:00+01:00 2020-01-01T00:30:00+01:00
+      0.000 2020-01-01T23:30:00+01:00 2020-01-01T00:00:00+01:00
+      0.000 2020-01-02T23:00:00+01:00 2020-01-02T23:30:00+01:00
+      0.000 2020-01-02T22:30:00+01:00 2020-01-02T23:00:00+01:00
+      0.000 2020-01-02T22:00:00+01:00 2020-01-02T22:30:00+01:00
+      0.000 2020-01-02T21:30:00+01:00 2020-01-02T22:00:00+01:00
+      0.000 2020-01-02T21:00:00+01:00 2020-01-02T21:30:00+01:00
+      0.000 2020-01-02T20:30:00+01:00 2020-01-02T21:00:00+01:00
+      0.000 2020-01-02T20:00:00+01:00 2020-01-02T20:30:00+01:00
+      0.000 2020-01-02T19:30:00+01:00 2020-01-02T20:00:00+01:00
+      0.000 2020-01-02T19:00:00+01:00 2020-01-02T19:30:00+01:00
 
 # If configuration has been set the following function can be called with no parameters
 Get-OctopusEnergyHelperElectricityUsed
 
 # Gas meter
-Get-OctopusEnergyHelperConsumption -mprn 1234567890123 -serial_number GM123456789
+Get-OctopusEnergyHelperConsumption -MPRN 1234567890123 -SerialNumber GM123456789
+consumption interval_start            interval_end
+----------- --------------            ------------
+      0.000 2020-01-01T00:00:00+01:00 2020-01-01T00:30:00+01:00
+      0.000 2020-01-01T23:30:00+01:00 2020-01-01T00:00:00+01:00
+      0.000 2020-01-02T23:00:00+01:00 2020-01-02T23:30:00+01:00
+      0.000 2020-01-02T22:30:00+01:00 2020-01-02T23:00:00+01:00
+      0.000 2020-01-02T22:00:00+01:00 2020-01-02T22:30:00+01:00
+      0.000 2020-01-02T21:30:00+01:00 2020-01-02T22:00:00+01:00
+      0.000 2020-01-02T21:00:00+01:00 2020-01-02T21:30:00+01:00
+      0.000 2020-01-02T20:30:00+01:00 2020-01-02T21:00:00+01:00
+      0.000 2020-01-02T20:00:00+01:00 2020-01-02T20:30:00+01:00
+      0.000 2020-01-02T19:30:00+01:00 2020-01-02T20:00:00+01:00
+      0.000 2020-01-02T19:00:00+01:00 2020-01-02T19:30:00+01:00
 
 # If configuration has been set the following function can be called with no parameters
 Get-OctopusEnergyHelperGasUsed

--- a/OctopusEnergy-Helpers/Public/EnergyProducts/Find-OctopusEnergyHelperAgileRate.ps1
+++ b/OctopusEnergy-Helpers/Public/EnergyProducts/Find-OctopusEnergyHelperAgileRate.ps1
@@ -3,19 +3,21 @@
    Find the desired target rate for the specified period of time under the Agile Octopus tariff
 .DESCRIPTION
    Retrieves Agile Octopus rates which meet the target for the specified duration. E.g Find the time period which has the lowest total rate over a 2 1/2 hours period.
-.PARAMETER apikey
+.PARAMETER APIKey
    The Octopus Energy API Key
-.PARAMETER timespan
+.PARAMETER Duration
+   The duration of time the lowest price is needed
+.PARAMETER Timespan
    The period of time which should be tracked
-.PARAMETER target
+.PARAMETER Target
    Value used to specify if the highest or lowest value should be found
-.PARAMETER gsp
+.PARAMETER GSP
    The Grid Supply Point (GSP) of the electricity meter
-.PARAMETER mpan
-   The mpan of the electricity meter
-.PARAMETER period_from
+.PARAMETER MPAN
+   The MPAN of the electricity meter
+.PARAMETER PeriodFrom
    Search through rates from the given datetime (inclusive).
-.PARAMETER period_to
+.PARAMETER PeriodTo
    Search through rates to the given datetime (exclusive).
 .INPUTS
    None
@@ -38,32 +40,34 @@ function Find-OctopusEnergyHelperAgileRate
    [CmdletBinding(SupportsShouldProcess=$true,DefaultParameterSetName='MPAN')]
    [OutputType([System.Collections.Generic.List[PSObject]])]
    Param(
-      [securestring]$ApiKey=(Get-OctopusEnergyHelperAPIAuth),
+      [securestring]$APIKey=(Get-OctopusEnergyHelperAPIAuth),
 
       [Parameter(Mandatory=$true,ParameterSetName='GSPCode')]
       [Parameter(Mandatory=$true,ParameterSetName='MPAN')]
-      [timespan]$duration,
+      [timespan]$Duration,
 
       [Parameter(ParameterSetName='GSPCode')]
       [Parameter(ParameterSetName='MPAN')]
       [ValidateSet("lowest","highest")]
-      [string]$target="lowest",
+      [string]$Timespan="lowest",
 
       [Parameter(Mandatory=$true,ParameterSetName='GSPCode')]
       [ValidateSet("A","B","C","D","E","F","G","H","J","K","L","M","N","P")]
-      [string]$gsp,
+      [string]$GSP,
 
       [Parameter(Mandatory=$false,ParameterSetName='MPAN')]
       [ValidateNotNullOrEmpty()]
-      [string]$mpan = (Get-OctopusEnergyHelperConfig -property mpan),
+      [string]$MPAN = (Get-OctopusEnergyHelperConfig -property mpan),
 
       [Parameter(ParameterSetName='GSPCode')]
       [Parameter(ParameterSetName='MPAN')]
-      [datetime]$period_from = $((Get-Date)),
+      [Alias("period_from")]
+      [datetime]$PeriodFrom = $((Get-Date)),
 
       [Parameter(ParameterSetName='GSPCode')]
       [Parameter(ParameterSetName='MPAN')]
-      [datetime]$period_to
+      [Alias("period_to")]
+      [datetime]$PeriodTo
    )
 
    if($mpan)

--- a/OctopusEnergy-Helpers/Public/EnergyProducts/Get-OctopusEnergyHelperEnergyProductList.ps1
+++ b/OctopusEnergy-Helpers/Public/EnergyProducts/Get-OctopusEnergyHelperEnergyProductList.ps1
@@ -4,19 +4,19 @@
    Retrieves the list of energy products
 .DESCRIPTION
    Retrieves the list of energy products
-.PARAMETER apikey
+.PARAMETER APIKey
    The Octopus Energy API Key
-.PARAMETER is_variable
+.PARAMETER Variable
    Show only variable products
-.PARAMETER is_green
+.PARAMETER Green
    Show only green products
-.PARAMETER is_tracker
+.PARAMETER Tracker
    Show only tracker products
-.PARAMETER is_prepay
+.PARAMETER Prepay
    Show only pre-pay products
-.PARAMETER is_business
+.PARAMETER Business
    Show only business products
-.PARAMETER available_at
+.PARAMETER AvailableAt
    Show products available for new agreements on the give datetime.
 .INPUTS
    None
@@ -26,52 +26,46 @@
    C:\PS>Get-OctopusEnergyHelperEnergyProductList
    Retrieve all energy products
 .EXAMPLE
-   C:\PS>Get-OctopusEnergyHelperEnergyProductList -available_at $((Get-Date).AddMonths(-1))
+   C:\PS>Get-OctopusEnergyHelperEnergyProductList -AvailableAt $((Get-Date).AddMonths(-1))
    Retrieve all energy products which are available in the last month
 .EXAMPLE
-   C:\PS>Get-OctopusEnergyHelperEnergyProductList -is_variable
+   C:\PS>Get-OctopusEnergyHelperEnergyProductList -Variable
    Retrieve all energy products which are variable rate only
+.LINK
+   https://developer.octopus.energy/docs/api/#energy-products
 #>
 function Get-OctopusEnergyHelperEnergyProductList
 {
    [CmdletBinding(SupportsShouldProcess=$true)]
    Param(
-      [securestring]$ApiKey=(Get-OctopusEnergyHelperAPIAuth),
+      [securestring]$APIKey=(Get-OctopusEnergyHelperAPIAuth),
 
-      [switch]$is_variable,
+      [Alias("is_variable")]
+      [switch]$Variable,
 
-      [switch]$is_green,
+      [Alias("is_green")]
+      [switch]$Green,
 
-      [switch]$is_tracker,
+      [Alias("is_tracker")]
+      [switch]$Tracker,
 
-      [switch]$is_prepay,
+      [Alias("is_prepay")]
+      [switch]$Prepay,
 
-      [switch]$is_business,
+      [Alias("is_business")]
+      [switch]$Business,
 
-      [datetime]$available_at
+      [Alias("available_at")]
+      [datetime]$AvailableAt
    )
-   $oeAPIKey = (New-Object PSCredential "user",$ApiKey).GetNetworkCredential().Password
+   $oeAPIKey = (New-Object PSCredential "user",$APIKey).GetNetworkCredential().Password
    $Credential = New-Object System.Management.Automation.PSCredential ($oeAPIKey, (New-Object System.Security.SecureString))
    $requestURL = Get-OctopusEnergyHelperBaseURL -endpoint products
 
-   $psParams = @{}
-   $ParameterList = (Get-Command -Name $MyInvocation.InvocationName).Parameters
-   $ParamsToIgnore = @("apikey")
-   foreach ($key in $ParameterList.keys)
-   {
-      $var = Get-Variable -Name $key -ErrorAction SilentlyContinue;
-      if($ParamsToIgnore -contains $var.Name)
-      {
-          continue
-      }
-      elseif($var.value -or $var.value -eq 0)
-      {
-         $value = $var.value
-         $psParams.Add($var.name,$value)
-      }
-   }
+   $allParameterValues = $MyInvocation | Get-OctopusEnergyHelperParameterValue -BoundParameters $PSBoundParameters
+   $apiParams = $MyInvocation | Get-OctopusEnergyHelperAPIParameter -Hashtable $allParameterValues -Exclude $paramsToIgnore
+   $apiParams = $apiParams | ConvertTo-OctopusEnergyHelperAPIParam
 
-   $apiParams = $psParams | ConvertTo-OctopusEnergyHelperAPIParam
    $requestParams = @{
       Credential = $Credential
       uri = $requestURL
@@ -79,7 +73,8 @@ function Get-OctopusEnergyHelperEnergyProductList
       method = "Get"
       ContentType = "application/x-www-form-urlencoded"
       body = $apiParams
-  }
+   }
+
    if( $pscmdlet.ShouldProcess("Octopus Energy API", "Retrieve Product List") )
    {
       $response = Get-OctopusEnergyHelperResponse -requestParams $requestParams

--- a/OctopusEnergy-Helpers/Public/EnergyProducts/README.md
+++ b/OctopusEnergy-Helpers/Public/EnergyProducts/README.md
@@ -6,7 +6,7 @@ The following are the module functions which work with the product API endpoint
 This cmdlet can be used create a HTML page with the supplied rates. A rate to be highlighted on the HTML page can be specified along with the desired set of values to highlight.
 
 ```powershell
-$agileRates = Get-OctopusEnergyHelperEnergyProductTariff -tariff_code "E-1R-AGILE-18-02-21-A" -period_from (Get-Date)
+$agileRates = Get-OctopusEnergyHelperEnergyProductTariff -TariffCode "E-1R-AGILE-18-02-21-A" -PeriodFrom (Get-Date)
 ($agileRates).'standard-unit-rates' | ConvertTo-OctopusEnergyHelperRateHTML -TargetRate 11 -Highlight Lower | Out-File .\AgileRate.html
 ```
 
@@ -14,26 +14,74 @@ $agileRates = Get-OctopusEnergyHelperEnergyProductTariff -tariff_code "E-1R-AGIL
 This cmdlet can be used to retrieve a desired target rate over a specified duration. E.g. Lowest rate in a continuous two hour block.
 
 ```powershell
-Find-OctopusEnergyHelperAgileRate -mpan 1234567890123 -duration (New-TimeSpan -hours 2) -target "lowest"
+Find-OctopusEnergyHelperAgileRate -MPAN 1234567890123 -Duration (New-TimeSpan -hours 2) -target "lowest"
 ```
 ### Get-OctopusEnergyHelperEnergyProduct
 This cmdlet can be used to retrieve the details for a specific energy product
 
 ```powershell
-Get-OctopusEnergyHelperEnergyProduct -product_code "AGILE-18-02-21"
+Get-OctopusEnergyHelperEnergyProduct -ProductCode "AGILE-18-02-21"
+
+code                                : AGILE-18-02-21
+full_name                           : Agile Octopus February 2018
+display_name                        : Agile Octopus
+description                         :
+is_variable                         : True
+is_green                            : True
+is_tracker                          : False
+is_prepay                           : False
+is_business                         : False
+is_restricted                       : False
+term                                : 12
+available_from                      : 2017-01-01T00:00:00Z
+available_to                        :
+tariffs_active_at                   : 2020-06-08T18:42:48.463789Z
+single_register_electricity_tariffs : @{_A=; _B=; _C=; _D=; _E=; _F=; _G=; _H=; _J=; _K=; _L=; _M=; _N=; _P=}
+dual_register_electricity_tariffs   :
+single_register_gas_tariffs         :
+sample_quotes                       : @{_A=; _B=; _C=; _D=; _E=; _F=; _G=; _H=; _J=; _K=; _L=; _M=; _N=; _P=}
+sample_consumption                  : @{electricity_single_rate=; electricity_dual_rate=; dual_fuel_single_rate=; dual_fuel_dual_rate=}
+links                               : {@{href=https://api.octopus.energy/v1/products/AGILE-18-02-21/; method=GET; rel=self}}
+brand                               : OCTOPUS_ENERGY
 ```
 ### Get-OctopusEnergyHelperEnergyProductList
 This cmdlet can be used to retrieve list of available energy products
 
 ```powershell
-Get-OctopusEnergyHelperEnergyProductList
+# Retrieve the product list information for Agile Octopus from the product list
+Get-OctopusEnergyHelperEnergyProductList | Where-Object {$_.display_name -eq "Agile Octopus"}
+
+code           : AGILE-18-02-21
+direction      : IMPORT
+full_name      : Agile Octopus February 2018
+display_name   : Agile Octopus
+description    :
+is_variable    : True
+is_green       : True
+is_tracker     : False
+is_prepay      : False
+is_business    : False
+is_restricted  : False
+term           : 12
+available_from : 2017-01-01T00:00:00Z
+available_to   :
+links          : {@{href=https://api.octopus.energy/v1/products/AGILE-18-02-21/; method=GET; rel=self}}
+brand          : OCTOPUS_ENERGY
 ```
 
 ### Get-OctopusEnergyHelperEnergyProductTariff
 This cmdlet can be used to retrieve the tariff details for a specific energy product
 
 ```powershell
-Get-OctopusEnergyHelperEnergyProductTariff -tariff_code "E-1R-AGILE-18-02-21-A"
+Get-OctopusEnergyHelperEnergyProductTariff -TariffCode "E-1R-AGILE-18-02-21-A"
+
+ProductCode         : AGILE-18-02-21
+TariffCode          : E-1R-AGILE-18-02-21-C
+FuelType            : electricity
+standing-charges    : @{value_exc_vat=20.0; value_inc_vat=21.0; valid_from=2017-01-01T00:00:00Z; valid_to=}
+standard-unit-rates : {@{value_exc_vat=4.8; value_inc_vat=5.04; valid_from=2020-06-09T21:30:00Z; valid_to=2020-06-09T22:00:00Z}, @{value_exc_vat=5.6; value_inc_vat=5.88;
+                      valid_from=2020-06-09T21:00:00Z; valid_to=2020-06-09T21:30:00Z}, @{value_exc_vat=5.6; value_inc_vat=5.88; valid_from=2020-06-09T20:30:00Z;
+                      valid_to=2020-06-09T21:00:00Z}, @{value_exc_vat=6.64; value_inc_vat=6.972; valid_from=2020-06-09T20:00:00Z; valid_to=2020-06-09T20:30:00Z}...}
 ```
 
 # Authors

--- a/OctopusEnergy-Helpers/Public/MeterPoint/Get-OctopusEnergyHelperMeterPoint.ps1
+++ b/OctopusEnergy-Helpers/Public/MeterPoint/Get-OctopusEnergyHelperMeterPoint.ps1
@@ -4,35 +4,37 @@
    Retrieves the meter point for a Octopus Energy electricity meter
 .DESCRIPTION
    Returns the meter point for a Octopus Energy electricity meter
-.PARAMETER apikey
+.PARAMETER APIKey
    The Octopus Energy API Key
-.PARAMETER mpan
-   The mpan of the electricity meter
+.PARAMETER MPAN
+   The MPAN of the electricity meter
 .INPUTS
    None
 .OUTPUTS
    Returns a PSCustomObject with details of the meter point
 .EXAMPLE
-   C:\PS>Get-OctopusEnergyHelperMeterPoint -mpan 1234567890
-   Retrieve meter point details for mpan 1234567890
+   C:\PS>Get-OctopusEnergyHelperMeterPoint -MPAN 1234567890
+   Retrieve meter point details for MPAN 1234567890
+.LINK
+   https://developer.octopus.energy/docs/api/#retrieve-a-meter-point
 #>
 function Get-OctopusEnergyHelperMeterPoint
 {
    [CmdletBinding(SupportsShouldProcess=$true)]
    Param(
-      [securestring]$ApiKey=(Get-OctopusEnergyHelperAPIAuth),
+      [securestring]$APIKey=(Get-OctopusEnergyHelperAPIAuth),
 
       [ValidateNotNullOrEmpty()]
-      [string]$mpan = (Get-OctopusEnergyHelperConfig -property mpan)
+      [string]$MPAN = (Get-OctopusEnergyHelperConfig -property MPAN)
    )
 
-   $oeAPIKey = (New-Object PSCredential "user",$ApiKey).GetNetworkCredential().Password
+   $oeAPIKey = (New-Object PSCredential "user",$APIKey).GetNetworkCredential().Password
    $Credential = New-Object System.Management.Automation.PSCredential ($oeAPIKey, (New-Object System.Security.SecureString))
 
-   if($mpan)
+   if($MPAN)
    {
       $URL = Get-OctopusEnergyHelperBaseURL -endpoint elecmp
-      $requestURL = "$URL$mpan/"
+      $requestURL = "$URL$MPAN/"
    }
 
    $requestParams = @{

--- a/OctopusEnergy-Helpers/Public/MeterPoint/README.md
+++ b/OctopusEnergy-Helpers/Public/MeterPoint/README.md
@@ -6,7 +6,11 @@ The following are the module functions which work with the meterpoint API endpoi
 This cmdlet retrieves the meter point information for the specified electricity meter
 
 ```powershell
-Get-OctopusEnergyHelperMeterPoint -mpan 1234567890123
+Get-OctopusEnergyHelperMeterPoint -MPAN 1234567890123
+
+gsp mpan          profile_class
+--- ----          -------------
+_A  1234567890123             1
 ```
 
 # Authors


### PR DESCRIPTION
Add functions for parsing parameters
* Get-OctopusEnergyHelperAPIParameter
* Get-OctopusEnergyHelperParameterValue

Change parameter names to Pascal case, update comment based help to match and add aliases for backwards compatibility.
* Get-OctopusEnergyHelperConsumption
* Get-OctopusEnergyHelperElectricityUsed
* Get-OctopusEnergyHelperGasUsed
* Find-OctopusEnergyHelperAgileRate
* Get-OctopusEnergyHelperEnergyProduct
* Get-OctopusEnergyHelperEnergyProductList
* Get-OctopusEnergyHelperEnergyProductTariff
* Get-OctopusEnergyHelperMeterPoint

Utilize `Get-OctopusEnergyHelperParameterValue` to retrieve bound and parameters with default values.
* Get-OctopusEnergyHelperElectricityUsed
* Get-OctopusEnergyHelperGasUsed

Utilize `Get-OctopusEnergyHelperParameterValue` to retrieve bound and parameters with default values.
Use `Get-OctopusEnergyHelperAPIParameter` to handle parameter exclusions and alias swapping.
* Get-OctopusEnergyHelperEnergyProduct
* Get-OctopusEnergyHelperEnergyProductList
* Get-OctopusEnergyHelperEnergyProductTariff